### PR TITLE
Remove invalid array indexing. Use std::vector instead. Refactor voltage calculations

### DIFF
--- a/esp32-example-can.yaml
+++ b/esp32-example-can.yaml
@@ -10,11 +10,11 @@ substitutions:
   # --------------------------------------
   # Battery Charging setting:
   # This is max charging amps eg 50A, for Bulk - Constant Current charging(CC), should be at least 10A less than BMS change current protection, 0.5C max
-  charge_a: "50"
+  charge_a: "80"
   # Absorption Voltage for Constant Voltage charging(CV). This is Absorption voltage you want the inverter to change with 55.2 eg 3.45v/cell for 16 cells 48V battery.
   absorption_v: "55.2"
   # Absorption time in minutes to hold charge voltage after charge voltage is reached eg 30
-  absorption_time: "30"
+  absorption_time: "60"
   # Rebulk offset, x Volts below absorption volatge battery will request rebulk, eg 55.2-3 = 52.5v, roughly 90% SOC.
   rebulk_offset: "3"
   # --------------------------------------
@@ -238,6 +238,7 @@ interval:
               
               if (id(absorption_script).is_running()) id(absorption_script).stop();
               id(charge_status) = "Bulk";
+              id(charging_current).state = ${charge_a};
 
             } else if (is_above_rebulk && is_below_absorption) { /// If in startup rebulk
               
@@ -258,24 +259,36 @@ interval:
 
             }
 
-            if (is_full && id(charge_status) != "Disabled") {
-              // Protect against overcharge. This will override all other conditions above
-              if (id(absorption_script).is_running()) id(absorption_script).stop();
-              id(charge_status) = "Wait";
+            if (id(charge_status) != "Disabled") {
+              if (is_full) {
+                // Protect against overcharge. This will override all other conditions above
+                if (id(absorption_script).is_running()) id(absorption_script).stop();
+                id(charge_status) = "Wait";
+              }
+
+              if (id(charging_current).state <= 0.0f) {
+                // If throttled down to 0 amps then we have finished a charge...
+                if (id(absorption_script).is_running()) id(absorption_script).stop();
+                id(charge_status) = "Wait";
+                id(charging_current).state = ${charge_a};
+              }
             }
 
-            if ((id(charge_status) == "Bulk") || (id(charge_status) == "Absorption") || (id(inverter_chg_on).state)) {
+            if ((id(charge_status) == "Bulk") || (id(charge_status) == "Absorption") || manual_charging) {
+              if (near_full) {
+                // Throttle down the current to keep from overvoltage
+                id(charging_current).state -= 1.0f;
+                
+                // Ensure we never go negative
+                if (id(charging_current).state <= 0.0f) id(charging_current).state = 0.0f;
+              }
+              
               auto desired_voltage = uint16_t(id(charging_voltage).state * 10);
               auto desired_current = uint16_t(id(charging_current).state * 10);
 
               if (id(charge_status) == "Absorption") {
-                if (near_full) {
-                  // Use 2A trickle charge when nearly full
-                  desired_current = 2 * 10; // 2A
-                } else {
-                  // Use 1/4 charging current when in the absorption phase
-                  desired_current = desired_current / 4;
-                }
+                // Use 1/4 charging current when in the absorption phase
+                // desired_current = desired_current / 4;
               }
 
               can_mesg[0] = desired_voltage & 0xff;

--- a/esp32-example-can.yaml
+++ b/esp32-example-can.yaml
@@ -16,7 +16,7 @@ substitutions:
   # Absorption time in minutes to hold charge voltage after charge voltage is reached eg 30
   absorption_time: "60"
   # Rebulk offset, x Volts below absorption volatge battery will request rebulk, eg 55.2-3 = 52.5v, roughly 90% SOC.
-  rebulk_offset: "3"
+  rebulk_offset: "2.1"
   # --------------------------------------
   # Battery Discharge setting:
   # Max discharge amps eg 100, should be at least 10A less than BMS over dischange current protection, 0.5C max
@@ -71,12 +71,30 @@ globals:
     type: std::string
     restore_value: no
     initial_value: '"Startup"'
+  - id: iteration_counter
+    type: int
+    restore_value: no
+    initial_value: "0"
+  - id: throttled_charge_current
+    type: int
+    restore_value: no
+    initial_value: "0"
 
 button:
   - platform: restart
     name: "Restart button"
     id: restart_button
     internal: true
+
+  # - platform: template
+  #   name: Decrease Charging Current
+  #   id: decrease_charging_current
+  #   icon: "mdi:emoticon-outline"
+  #   on_press:
+  #     - lambda: |-
+  #         auto charging_current_call = charging_current->make_call();
+  #         charging_current_call.number_decrement(false);
+  #         charging_current_call.perform();
 
 wifi:
   ssid: !secret wifi_ssid
@@ -145,6 +163,9 @@ interval:
       - canbus.send: # Warning, Alarms
           can_id: 0x359
           data: !lambda |-
+            id(iteration_counter)++;
+            id(iteration_count).publish_state(id(iteration_counter));
+
             std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0, 0, 0};
 
             uint16_t jk_errormask = id(errors_bitmask).state;
@@ -200,6 +221,9 @@ interval:
             bool charging_allowed = id(charging_switch).state && id(inverter_charging).state;
             bool charging_disallowed = !charging_allowed;
 
+            bool discharging_allowed = id(discharging_switch).state && id(inverter_discharging).state;
+            bool discharging_disallowed = !discharging_allowed;
+
             bool manual_charging = id(inverter_chg_on).state;
 
             auto rebulk_voltage = id(charging_voltage).state - ${rebulk_offset};
@@ -210,86 +234,107 @@ interval:
             bool is_below_rebulk = id(total_voltage).state <= rebulk_voltage;
             bool is_above_rebulk = !is_below_rebulk;
 
-            bool is_below_absorption = id(total_voltage).state < absorb_voltage && soc < 100;
+            bool is_below_absorption = id(total_voltage).state < absorb_voltage;
             bool is_above_absorption = !is_below_absorption;
 
-            bool near_full = id(max_cell_voltage).state >= 3.5f || id(delta_cell_voltage).state > 0.1f;
+            // This is used to throttle the charge current
+            bool near_full = id(max_cell_voltage).state >= 3.5f || id(delta_cell_voltage).state > 0.08f;
             bool is_full = id(max_cell_voltage).state >= 3.55f;
 
             ESP_LOGI("main", "SOC: %u | MAX: %f | DELTA: %f", soc, id(max_cell_voltage).state, id(delta_cell_voltage).state);
 
             if (charging_disallowed) {
               
+              ESP_LOGI("main", "State Machine: Disabled (Charging Disallowed)");
+
               id(charge_status) = "Disabled";
 
             } else if (manual_charging) {
               
+              ESP_LOGI("main", "State Machine: Bulk Manually (Manual Charging)");
+
               id(charge_status) = "Bulk Manually";
+              id(charging_stopped_cause).publish_state("");
 
             } else if (charging_allowed && id(charge_status) == "Disabled") {
               
+              ESP_LOGI("main", "State Machine: Disabled => Wait");
+
               id(charge_status) = "Wait";
 
             } else if (!manual_charging && id(charge_status) == "Bulk Manually") {
               
+              ESP_LOGI("main", "State Machine: Bulk Manually => Wait");
+              
               id(charge_status) = "Wait";
 
             } else if (is_below_rebulk) { /// Bulk Charge eg 53.6v 10% 
+
+              ESP_LOGI("main", "State Machine: Bulk (Below Rebulk)");
               
               if (id(absorption_script).is_running()) id(absorption_script).stop();
               id(charge_status) = "Bulk";
-              id(charging_current).state = ${charge_a};
+              id(charging_stopped_cause).publish_state("");
+              id(throttled_charge_current) = id(charging_current).state;
 
             } else if (is_above_rebulk && is_below_absorption) { /// If in startup rebulk
               
+              ESP_LOGI("main", "State Machine: (Above Rebulk but Below Absorption)");
+
               if (id(charge_status) == "Startup") {
+                ESP_LOGI("main", "State Machine: Startup => Bulk");
+
                 id(charge_status) = "Bulk"; /// If in startup, 10% low rebulk
+                id(charging_stopped_cause).publish_state("");
+                id(throttled_charge_current) = id(charging_current).state;
               }
 
             } else if (is_above_absorption) { /// 10 % from top start absorption timer
               
+              ESP_LOGI("main", "State Machine: (Is Above Absorption)");
+
               if (id(charge_status) == "Bulk") {
+                ESP_LOGI("main", "State Machine: Bulk => Absorption");
+
                 id(charge_status) = "Absorption";
                 if (!id(absorption_script).is_running()) id(absorption_script).execute();
               }
 
             } else {
 
+              ESP_LOGI("main", "State Machine: Wait (Default)");
+
               id(charge_status) = "Wait";
 
             }
 
             if (id(charge_status) != "Disabled") {
-              if (is_full) {
-                // Protect against overcharge. This will override all other conditions above
+              // Protect against overcharge. This will override all other conditions above
+              // If throttled down to 0 amps then we have finished a charge...
+              if (is_full || id(throttled_charge_current) == 0) {
                 if (id(absorption_script).is_running()) id(absorption_script).stop();
                 id(charge_status) = "Wait";
-              }
 
-              if (id(charging_current).state <= 0.0f) {
-                // If throttled down to 0 amps then we have finished a charge...
-                if (id(absorption_script).is_running()) id(absorption_script).stop();
-                id(charge_status) = "Wait";
-                id(charging_current).state = ${charge_a};
+                id(charging_stopped_cause).publish_state("Overvoltage Protection");
               }
             }
 
-            if ((id(charge_status) == "Bulk") || (id(charge_status) == "Absorption") || manual_charging) {
-              if (near_full) {
-                // Throttle down the current to keep from overvoltage
-                id(charging_current).state -= 1.0f;
-                
-                // Ensure we never go negative
-                if (id(charging_current).state <= 0.0f) id(charging_current).state = 0.0f;
-              }
-              
-              auto desired_voltage = uint16_t(id(charging_voltage).state * 10);
-              auto desired_current = uint16_t(id(charging_current).state * 10);
+            if ((id(charge_status) == "Bulk") || (id(charge_status) == "Absorption") || (id(charge_status) == "Bulk Manually")) {
+              bool every_10_iterations = ((uint32_t)(id(iteration_counter)) % 10) == 0;
 
-              if (id(charge_status) == "Absorption") {
-                // Use 1/4 charging current when in the absorption phase
-                // desired_current = desired_current / 4;
+              if (near_full && every_10_iterations) {
+                // Throttle down the current to keep from overvoltage
+                if (id(throttled_charge_current) > 10) {
+                  // Reduce by 20%
+                  id(throttled_charge_current) = (id(throttled_charge_current) * 4) / 5;
+                } else if (id(throttled_charge_current) > 0) {
+                  // Reduce by 1A
+                  id(throttled_charge_current)--;
+                }
               }
+
+              auto desired_voltage = uint16_t(id(charging_voltage).state * 10);
+              auto desired_current = uint16_t(id(throttled_charge_current) * 10);
 
               can_mesg[0] = desired_voltage & 0xff;
               can_mesg[1] = desired_voltage >> 8 & 0xff;
@@ -302,14 +347,14 @@ interval:
               can_mesg[3] = 0;
             }
 
-            if ((!id(charging_switch).state) || (!id(inverter_charging).state)) { /// Overides to disable charging
+            if (charging_disallowed) { /// Overides to disable charging
               can_mesg[0] = 0;
               can_mesg[1] = 0;
               can_mesg[2] = 0;
               can_mesg[3] = 0;
             }
 
-            if ((id(discharging_switch).state) && (id(inverter_discharging).state)) {
+            if (discharging_allowed) {
               can_mesg[4] = uint16_t(${discharge_a} * 10) & 0xff;
               can_mesg[5] = uint16_t(${discharge_a} * 10) >> 8 & 0xff;
             } else {
@@ -321,6 +366,7 @@ interval:
             can_mesg[7] = uint16_t(${min_dischange_v} * 10) >> 8 & 0xff;
 
             id(charging_status).publish_state(id(charge_status));
+            id(throttled_charge_current_sensor).publish_state(id(throttled_charge_current));
 
             ESP_LOGI("main", "send can id: 0x351 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
             ESP_LOGI("main", "send can id: Charge Status %s", id(charge_status).c_str());
@@ -338,8 +384,10 @@ interval:
             auto soh = uint16_t(round(((id(charging_cycles).state / ${max_cycles}) - 1) * -100));
 
             // Fool the inverter into continuing to charge beyond what the BMS thinks is "100%"
-            if (soc == 100 && id(charge_status) == "Absorption") {
-              soc = 99;
+            if (id(charge_status) == "Bulk" || id(charge_status) == "Absorption") {
+              if (soc == 100) {
+                soc = 99;
+              }
             }
 
             can_mesg[0] = soc & 0xff; /// 15 & 0xff; 
@@ -675,6 +723,13 @@ sensor:
                 (minutes ? to_string(minutes) + "m " : "") +
                 (to_string(seconds) + "s")
               ).c_str();
+  - platform: template
+    name: "${name} Iteration Count"
+    id: iteration_count
+  - platform: template
+    name: "${name} Throttled Charge Current"
+    id: throttled_charge_current_sensor
+    unit_of_measurement: A
 
 text_sensor:
   - platform: jk_bms
@@ -702,6 +757,9 @@ text_sensor:
   - platform: template
     name: "${name} Charging Status"
     id: charging_status
+  - platform: template
+    name: "${name} Charging Stopped Cause"
+    id: charging_stopped_cause
 
 # Slider
 number:
@@ -727,13 +785,19 @@ number:
     unit_of_measurement: A
     icon: mdi:current-dc
     optimistic: true
+    set_action: 
+      - lambda: |-
+          id(throttled_charge_current) = x;
+          id(throttled_charge_current_sensor).publish_state(id(throttled_charge_current));
 
 script:
   - id: absorption_script
     then:
       - lambda: id(charge_status) = "Absorption";
       - delay: ${absorption_time}min
-      - lambda: id(charge_status) = "Wait";
+      - lambda: |-
+          id(charge_status) = "Wait";
+          id(charging_stopped_cause).publish_state("Absorption Complete");
 
 switch:
   - platform: template

--- a/esp32-example-can.yaml
+++ b/esp32-example-can.yaml
@@ -52,15 +52,15 @@ esp32:
     type: esp-idf
     version: latest
 
-external_components:
-  - source: ${external_components_source}
-    refresh: 0s
+# external_components:
+#   - source: ${external_components_source}
+#     refresh: 0s
 
 #### Useful for local development. No need to re-clone the repo when we already have it right here...
-# external_components:
-#   - source:
-#       type: local
-#       path: components
+external_components:
+  - source:
+      type: local
+      path: components
 
 globals:
   - id: can_305_rx
@@ -197,38 +197,91 @@ interval:
           data: !lambda |-
             std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0, 0, 0};
 
+            bool charging_allowed = id(charging_switch).state && id(inverter_charging).state;
+            bool charging_disallowed = !charging_allowed;
+
+            bool manual_charging = id(inverter_chg_on).state;
+
             auto rebulk_voltage = id(charging_voltage).state - ${rebulk_offset};
             auto absorb_voltage = id(charging_voltage).state - 0.05;
 
-            if ((!id(charging_switch).state) || (!id(inverter_charging).state)) {
+            auto soc = uint16_t(id(capacity_remaining).state);
+
+            bool is_below_rebulk = id(total_voltage).state <= rebulk_voltage;
+            bool is_above_rebulk = !is_below_rebulk;
+
+            bool is_below_absorption = id(total_voltage).state < absorb_voltage && soc < 100;
+            bool is_above_absorption = !is_below_absorption;
+
+            bool near_full = id(max_cell_voltage).state >= 3.5f || id(delta_cell_voltage).state > 0.1f;
+            bool is_full = id(max_cell_voltage).state >= 3.55f;
+
+            ESP_LOGI("main", "SOC: %u | MAX: %f | DELTA: %f", soc, id(max_cell_voltage).state, id(delta_cell_voltage).state);
+
+            if (charging_disallowed) {
+              
               id(charge_status) = "Disabled";
-            } else if (id(inverter_chg_on).state) {
+
+            } else if (manual_charging) {
+              
               id(charge_status) = "Bulk Manually";
-            } else if ((id(charging_switch).state) && (id(inverter_charging).state) && (id(charge_status) == "Disabled")) {
+
+            } else if (charging_allowed && id(charge_status) == "Disabled") {
+              
               id(charge_status) = "Wait";
-            } else if ((!id(inverter_chg_on).state) && (id(charge_status) == "Bulk Manually")) {
+
+            } else if (!manual_charging && id(charge_status) == "Bulk Manually") {
+              
               id(charge_status) = "Wait";
-            } else if (id(total_voltage).state <= rebulk_voltage) { ///Bulk Charge eg 53.6v 10% 
+
+            } else if (is_below_rebulk) { /// Bulk Charge eg 53.6v 10% 
+              
               if (id(absorption_script).is_running()) id(absorption_script).stop();
               id(charge_status) = "Bulk";
-            } else if ((id(total_voltage).state > rebulk_voltage) && (id(total_voltage).state < absorb_voltage)) { ///If in startup rebulk
+
+            } else if (is_above_rebulk && is_below_absorption) { /// If in startup rebulk
+              
               if (id(charge_status) == "Startup") {
                 id(charge_status) = "Bulk"; /// If in startup, 10% low rebulk
               }
-            } else if (id(total_voltage).state >= absorb_voltage) { ///10 % from top start absorption timer
+
+            } else if (is_above_absorption) { /// 10 % from top start absorption timer
+              
               if (id(charge_status) == "Bulk") {
                 id(charge_status) = "Absorption";
                 if (!id(absorption_script).is_running()) id(absorption_script).execute();
               }
+
             } else {
+
+              id(charge_status) = "Wait";
+
+            }
+
+            if (is_full && id(charge_status) != "Disabled") {
+              // Protect against overcharge. This will override all other conditions above
+              if (id(absorption_script).is_running()) id(absorption_script).stop();
               id(charge_status) = "Wait";
             }
 
             if ((id(charge_status) == "Bulk") || (id(charge_status) == "Absorption") || (id(inverter_chg_on).state)) {
-              can_mesg[0] = uint16_t(id(charging_voltage).state * 10) & 0xff;
-              can_mesg[1] = uint16_t(id(charging_voltage).state * 10) >> 8 & 0xff;
-              can_mesg[2] = uint16_t(id(charging_current).state * 10) & 0xff;
-              can_mesg[3] = uint16_t(id(charging_current).state * 10) >> 8 & 0xff;
+              auto desired_voltage = uint16_t(id(charging_voltage).state * 10);
+              auto desired_current = uint16_t(id(charging_current).state * 10);
+
+              if (id(charge_status) == "Absorption") {
+                if (near_full) {
+                  // Use 2A trickle charge when nearly full
+                  desired_current = 2 * 10; // 2A
+                } else {
+                  // Use 1/4 charging current when in the absorption phase
+                  desired_current = desired_current / 4;
+                }
+              }
+
+              can_mesg[0] = desired_voltage & 0xff;
+              can_mesg[1] = desired_voltage >> 8 & 0xff;
+              can_mesg[2] = desired_current & 0xff;
+              can_mesg[3] = desired_current >> 8 & 0xff;
             } else {
               can_mesg[0] = 0;
               can_mesg[1] = 0;
@@ -268,10 +321,16 @@ interval:
           data: !lambda |-
             std::vector<uint8_t> can_mesg = {0, 0, 0, 0};
 
-            int soh = round(((id(charging_cycles).state/${max_cycles})-1)*-100);
+            auto soc = uint16_t(id(capacity_remaining).state);
+            auto soh = uint16_t(round(((id(charging_cycles).state / ${max_cycles}) - 1) * -100));
 
-            can_mesg[0] = uint16_t(id(capacity_remaining).state) & 0xff; /// 15 & 0xff; 
-            can_mesg[1] = uint16_t(id(capacity_remaining).state) >> 8 & 0xff; /// 15 >> 8 & 0xff; 
+            // Fool the inverter into continuing to charge beyond what the BMS thinks is "100%"
+            if (soc == 100 && id(charge_status) == "Absorption") {
+              soc = 99;
+            }
+
+            can_mesg[0] = soc & 0xff; /// 15 & 0xff; 
+            can_mesg[1] = soc >> 8 & 0xff; /// 15 >> 8 & 0xff; 
             can_mesg[2] = soh & 0xff;
             can_mesg[3] = soh >> 8 & 0xff;
 
@@ -413,6 +472,7 @@ sensor:
       id: max_voltage_cell
       name: "${name} max voltage cell"
     delta_cell_voltage:
+      id: delta_cell_voltage
       name: "${name} delta cell voltage"
     average_cell_voltage:
       name: "${name} average cell voltage"

--- a/esp32-example-can.yaml
+++ b/esp32-example-can.yaml
@@ -1,42 +1,42 @@
 # Version info, for full change log:- https://github.com/Uksa007/esphome-jk-bms-can/discussions/2
 # V1.12 fix discharge current
 substitutions:
-# --------------------------
-# name that will appear in esphome and homeassistant.
+  # --------------------------
+  # name that will appear in esphome and homeassistant.
   name: jk-bms-can
-# --------------------------
-# Number of Battery modules max 8. Each LX U5.4-L battery is 5.4kWh, select the number closest to your capactiy eg 3.2V * 280Ah * 16 = 14.3kWh
+  # --------------------------
+  # Number of Battery modules max 8. Each LX U5.4-L battery is 5.4kWh, select the number closest to your capactiy eg 3.2V * 280Ah * 16 = 14.3kWh
   batt_modules: "3"
-# --------------------------------------
-# Battery Charging setting:
-# This is max charging amps eg 50A, for Bulk - Constant Current charging(CC), should be at least 10A less than BMS change current protection, 0.5C max 
+  # --------------------------------------
+  # Battery Charging setting:
+  # This is max charging amps eg 50A, for Bulk - Constant Current charging(CC), should be at least 10A less than BMS change current protection, 0.5C max
   charge_a: "50"
-# Absorption Voltage for Constant Voltage charging(CV). This is Absorption voltage you want the inverter to change with 55.2 eg 3.45v/cell for 16 cells 48V battery. 
+  # Absorption Voltage for Constant Voltage charging(CV). This is Absorption voltage you want the inverter to change with 55.2 eg 3.45v/cell for 16 cells 48V battery.
   absorption_v: "55.2"
-# Absorption time in minutes to hold charge voltage after charge voltage is reached eg 30
+  # Absorption time in minutes to hold charge voltage after charge voltage is reached eg 30
   absorption_time: "30"
-# Rebulk offset, x Volts below absorption volatge battery will request rebulk, eg 55.2-3 = 52.5v, roughly 90% SOC.
+  # Rebulk offset, x Volts below absorption volatge battery will request rebulk, eg 55.2-3 = 52.5v, roughly 90% SOC.
   rebulk_offset: "3"
-# --------------------------------------
-# Battery Discharge setting:
-# Max discharge amps eg 100, should be at least 10A less than BMS over dischange current protection, 0.5C max
+  # --------------------------------------
+  # Battery Discharge setting:
+  # Max discharge amps eg 100, should be at least 10A less than BMS over dischange current protection, 0.5C max
   discharge_a: "100"
-# Minimum discharge voltage eg 48v/16 = 3V per cell
+  # Minimum discharge voltage eg 48v/16 = 3V per cell
   min_dischange_v: "48"
-# --------------------------------------
-# Battery State of Health (SOH) setting:
-# Maximum charging cycles is used to calculate the battey SOH, LF280K=6000.0 LF280=3000.0 (decimal is required)
+  # --------------------------------------
+  # Battery State of Health (SOH) setting:
+  # Maximum charging cycles is used to calculate the battey SOH, LF280K=6000.0 LF280=3000.0 (decimal is required)
   max_cycles: "6000.0"
-# --------------------------------------
-# ESP32 CAN/Serail port pins:
-# GPIO pins your CAN bus transceiver(TJA1050) is connected to the ESP, note! TX->TX and RX->RX. 
+  # --------------------------------------
+  # ESP32 CAN/Serail port pins:
+  # GPIO pins your CAN bus transceiver(TJA1050) is connected to the ESP, note! TX->TX and RX->RX.
   can_tx_pin: GPIO23
   can_rx_pin: GPIO22
-# GPIO pins your JK-BMS RS485(TTL) is connected to the ESP TX->RX and RX->TX. 
+  # GPIO pins your JK-BMS RS485(TTL) is connected to the ESP TX->RX and RX->TX.
   tx_pin: GPIO17
   rx_pin: GPIO16
-# --------------------------------------
-#### Don't make changes below this ####
+  # --------------------------------------
+  #### Don't make changes below this ####
   external_components_source: github://uksa007/esphome-jk-bms-can@main
 
 esphome:
@@ -56,11 +56,17 @@ external_components:
   - source: ${external_components_source}
     refresh: 0s
 
+#### Useful for local development. No need to re-clone the repo when we already have it right here...
+# external_components:
+#   - source:
+#       type: local
+#       path: components
+
 globals:
   - id: can_305_rx
     type: int
     restore_value: no
-    initial_value: '0'
+    initial_value: "0"
   - id: charge_status
     type: std::string
     restore_value: no
@@ -75,7 +81,6 @@ button:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
-  domain: !secret domain
 
 ota:
 logger:
@@ -126,14 +131,13 @@ canbus:
     can_id: 4
     bit_rate: 500kbps
     on_frame:
-    - can_id: 0x305 # SMA/LG/Pylon/Goodwe reply
-      then:
-        - light.toggle:
-            id: led_buitin
-        - lambda: |-
-            // ESP_LOGI("main", "received can id: 0x305 ACK");
-            id(can_305_rx) = 0;
-
+      - can_id: 0x305 # SMA/LG/Pylon/Goodwe reply
+        then:
+          - light.toggle:
+              id: led_buitin
+          - lambda: |-
+              // ESP_LOGI("main", "received can id: 0x305 ACK");
+              id(can_305_rx) = 0;
 
 interval:
   - interval: 1000ms
@@ -141,155 +145,191 @@ interval:
       - canbus.send: # Warning, Alarms
           can_id: 0x359
           data: !lambda |-
-            uint8_t can_mesg[] = {0, 0};
+            std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0, 0, 0};
+
             uint16_t jk_errormask = id(errors_bitmask).state;
             int batt_mods = ${batt_modules};
+
             /// Alarms
             if ((jk_errormask & 0x04) | (jk_errormask & 0x80) | (jk_errormask & 0x400)) { /// Hight.Voltage.Alarm JK bit 2,7,10 
-               can_mesg[0] = 0x02; /// bit 1
+              can_mesg[0] = 0x02; /// bit 1
             }
             if ((jk_errormask & 0x08) | (jk_errormask & 0x800)) { ///Low.Voltage.Alarm JK bit 3,11 
-               can_mesg[0] = can_mesg[0] | 0x04; /// bit 2
+              can_mesg[0] = can_mesg[0] | 0x04; /// bit 2
             }
             if ((jk_errormask & 0x02) | (jk_errormask & 0x10) | (jk_errormask & 0x100)) { //Hight.Temp.Alarm JK bit 1,4,8
-               can_mesg[0] = can_mesg[0] | 0x08; /// bit 3
+              can_mesg[0] = can_mesg[0] | 0x08; /// bit 3
             }
             if (jk_errormask & 0x200) { ///Low.Temp.Alarm JK bit 9
-               can_mesg[0] = can_mesg[0] | 0x10; /// bit 4
+              can_mesg[0] = can_mesg[0] | 0x10; /// bit 4
             }
             if (jk_errormask & 0x40) { ///Discharge.Over.Current JK bit 6
-               can_mesg[0] = can_mesg[0] | 0x80; /// bit 7
+              can_mesg[0] = can_mesg[0] | 0x80; /// bit 7
             }
             if (jk_errormask & 0x20) { ///Charge.Over.Current JK bit 5
-               can_mesg[1] = 0x01; /// bit 0
+              can_mesg[1] = 0x01; /// bit 0
             }
             if ((jk_errormask & 0x1000) | (jk_errormask & 0x2000)) { /// BMS Internal JK bit 12,13
-               can_mesg[1] = can_mesg[1] | 0x08; /// bit 3
+              can_mesg[1] = can_mesg[1] | 0x08; /// bit 3
             }
             if (jk_errormask & 0x80) { /// Cell Imbalance JK bit 7
-               can_mesg[1] = can_mesg[1] | 0x10; /// bit 4 
+              can_mesg[1] = can_mesg[1] | 0x10; /// bit 4 
             }
+
             /// Warnings
             can_mesg[2] = 0x00;
             can_mesg[3] = 0x00; /// test
+
             /// Flags
             can_mesg[4] = batt_mods; ///Module in parallel
             can_mesg[5] = 0x00;
             can_mesg[6] = 0x00;
             can_mesg[7] = 0x00; ///DIP switches 1,3 10000100 0x84
+
             ESP_LOGI("main", "send can id: 0x359 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
-            return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # BMS instructs inverter: Charge Volts, Charge Amps, Discharge Amps, Min voltage
           can_id: 0x351
           data: !lambda |-
-            uint8_t can_mesg[7];
-            if ((!id(charging_switch).state) | (!id(inverter_charging).state)) {
-               id(charge_status) = "Disabled";
+            std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0, 0, 0};
+
+            auto rebulk_voltage = id(charging_voltage).state - ${rebulk_offset};
+            auto absorb_voltage = id(charging_voltage).state - 0.05;
+
+            if ((!id(charging_switch).state) || (!id(inverter_charging).state)) {
+              id(charge_status) = "Disabled";
             } else if (id(inverter_chg_on).state) {
-                id(charge_status) = "Bulk Manually";
-            } else if ((id(charging_switch).state) & (id(inverter_charging).state) & (id(charge_status) == "Disabled")) {
-               id(charge_status) = "Wait";
-            } else if ((!id(inverter_chg_on).state) & (id(charge_status) == "Bulk Manually")) {
-               id(charge_status) = "Wait";
-            } else if (id(total_voltage).state <= (id(charging_voltage).state - ${rebulk_offset})) { ///Bulk Charge eg 53.6v 10% 
-                if (id(absorption_script).is_running()) id(absorption_script).stop();
-                id(charge_status) = "Bulk";
-            } else if ((id(total_voltage).state > (id(charging_voltage).state - ${rebulk_offset})) & (id(total_voltage).state < (id(charging_voltage).state - 0.05))) { ///If in startup rebulk
-                     if (id(charge_status) == "Startup") {
-                        id(charge_status) = "Bulk"; /// If in startup, 10% low rebulk
-                     }
-            } else if (id(total_voltage).state >= (id(charging_voltage).state  - 0.05)) { ///10 % from top start absorption timer
-                     if (id(charge_status) == "Bulk") {
-                        id(charge_status) = "Absorption";
-                        if (!id(absorption_script).is_running()) id(absorption_script).execute();
-                     }
+              id(charge_status) = "Bulk Manually";
+            } else if ((id(charging_switch).state) && (id(inverter_charging).state) && (id(charge_status) == "Disabled")) {
+              id(charge_status) = "Wait";
+            } else if ((!id(inverter_chg_on).state) && (id(charge_status) == "Bulk Manually")) {
+              id(charge_status) = "Wait";
+            } else if (id(total_voltage).state <= rebulk_voltage) { ///Bulk Charge eg 53.6v 10% 
+              if (id(absorption_script).is_running()) id(absorption_script).stop();
+              id(charge_status) = "Bulk";
+            } else if ((id(total_voltage).state > rebulk_voltage) && (id(total_voltage).state < absorb_voltage)) { ///If in startup rebulk
+              if (id(charge_status) == "Startup") {
+                id(charge_status) = "Bulk"; /// If in startup, 10% low rebulk
+              }
+            } else if (id(total_voltage).state >= absorb_voltage) { ///10 % from top start absorption timer
+              if (id(charge_status) == "Bulk") {
+                id(charge_status) = "Absorption";
+                if (!id(absorption_script).is_running()) id(absorption_script).execute();
+              }
             } else {
-                id(charge_status) = "Wait";
+              id(charge_status) = "Wait";
             }
-            if ((id(charge_status) == "Bulk") | (id(charge_status) == "Absorption") | (id(inverter_chg_on).state)) {
-               can_mesg[0] = uint16_t(id(charging_voltage).state * 10) & 0xff;
-               can_mesg[1] = uint16_t(id(charging_voltage).state * 10) >> 8 & 0xff;
-               can_mesg[2] = uint16_t(id(charging_current).state * 10) & 0xff;
-               can_mesg[3] = uint16_t(id(charging_current).state * 10) >> 8 & 0xff;
+
+            if ((id(charge_status) == "Bulk") || (id(charge_status) == "Absorption") || (id(inverter_chg_on).state)) {
+              can_mesg[0] = uint16_t(id(charging_voltage).state * 10) & 0xff;
+              can_mesg[1] = uint16_t(id(charging_voltage).state * 10) >> 8 & 0xff;
+              can_mesg[2] = uint16_t(id(charging_current).state * 10) & 0xff;
+              can_mesg[3] = uint16_t(id(charging_current).state * 10) >> 8 & 0xff;
             } else {
-               can_mesg[0] = 0;
-               can_mesg[1] = 0;
-               can_mesg[2] = 0;
-               can_mesg[3] = 0;
+              can_mesg[0] = 0;
+              can_mesg[1] = 0;
+              can_mesg[2] = 0;
+              can_mesg[3] = 0;
             }
-            if ((!id(charging_switch).state) | (!id(inverter_charging).state)) { /// Overides to disable charging
-               can_mesg[0] = 0;
-               can_mesg[1] = 0;
-               can_mesg[2] = 0;
-               can_mesg[3] = 0;
+
+            if ((!id(charging_switch).state) || (!id(inverter_charging).state)) { /// Overides to disable charging
+              can_mesg[0] = 0;
+              can_mesg[1] = 0;
+              can_mesg[2] = 0;
+              can_mesg[3] = 0;
             }
-            if ((id(discharging_switch).state) & (id(inverter_discharging).state)) {
+
+            if ((id(discharging_switch).state) && (id(inverter_discharging).state)) {
               can_mesg[4] = uint16_t(${discharge_a} * 10) & 0xff;
               can_mesg[5] = uint16_t(${discharge_a} * 10) >> 8 & 0xff;
             } else {
-               can_mesg[4] = 0x00;
-               can_mesg[5] = 0x00;
+              can_mesg[4] = 0x00;
+              can_mesg[5] = 0x00;
             }
+
             can_mesg[6] = uint16_t(${min_dischange_v} * 10) & 0xff;
             can_mesg[7] = uint16_t(${min_dischange_v} * 10) >> 8 & 0xff;
+
             id(charging_status).publish_state(id(charge_status));
+
             ESP_LOGI("main", "send can id: 0x351 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
             ESP_LOGI("main", "send can id: Charge Status %s", id(charge_status).c_str());
-            return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # Actual SOC, SOH
           can_id: 0x355
           data: !lambda |-
+            std::vector<uint8_t> can_mesg = {0, 0, 0, 0};
+
             int soh = round(((id(charging_cycles).state/${max_cycles})-1)*-100);
-            uint8_t can_mesg[3];
+
             can_mesg[0] = uint16_t(id(capacity_remaining).state) & 0xff; /// 15 & 0xff; 
             can_mesg[1] = uint16_t(id(capacity_remaining).state) >> 8 & 0xff; /// 15 >> 8 & 0xff; 
             can_mesg[2] = soh & 0xff;
             can_mesg[3] = soh >> 8 & 0xff;
+
             ESP_LOGI("main", "send can id: 0x355 hex: %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3]);
-            return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # Actual Volts, Amps, Temp
           can_id: 0x356
           data: !lambda |-
-            uint8_t can_mesg[5];
+            std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0};
+
             can_mesg[0] = uint16_t(id(total_voltage).state * 100) & 0xff; 
             can_mesg[1] = uint16_t(id(total_voltage).state * 100) >> 8 & 0xff;
             can_mesg[2] = int16_t(id(current).state * 10) & 0xff;
             can_mesg[3] = int16_t(id(current).state * 10) >> 8 & 0xff; 
             can_mesg[4] = int16_t(id(power_tube_temperature).state * 10) & 0xff;
             can_mesg[5] = int16_t(id(power_tube_temperature).state * 10) >> 8 & 0xff;
+
             ESP_LOGI("main", "send can id: 0x356 hex: %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5]);
-            return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # Request flag to Enable/Disable: Charge, Discharge
           can_id: 0x35C
           data: !lambda |-
-            uint8_t can_mesg[1];
+            std::vector<uint8_t> can_mesg = {0, 0};
+
             if ((id(charging_switch).state) & (id(inverter_charging).state)) {
                can_mesg[0] = 0x80;
             } else {
                can_mesg[0] = 0x00;
             }
+
             if ((id(discharging_switch).state) & (id(inverter_discharging).state)) {
                can_mesg[0] = can_mesg[0] | 0x40;
             }
+
             can_mesg[1] = 0x00;
+
             ESP_LOGI("main", "send can id: 0x35C hex: %x %x", can_mesg[0], can_mesg[1]);
-            return {can_mesg[0], can_mesg[1]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # Actual Max Cell Temp, Min Cell Temp, Max Cell V, Min Cell V
           can_id: 0x70
           data: !lambda |-
+            std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0, 0, 0};
+
             int max_cell_voltage_i = id(max_cell_voltage).state * 100.0;
             int min_cell_voltage_i = id(min_cell_voltage).state * 100.0;
-            uint8_t can_mesg[7];
+
             can_mesg[0] = int16_t(max(id(temperature_sensor_1).state, id(temperature_sensor_2).state)* 10) & 0xff;
             can_mesg[1] = int16_t(max(id(temperature_sensor_1).state, id(temperature_sensor_2).state)* 10) >> 8 & 0xff;
             can_mesg[2] = int16_t(min(id(temperature_sensor_1).state, id(temperature_sensor_2).state)* 10) & 0xff;
@@ -298,14 +338,18 @@ interval:
             can_mesg[5] = max_cell_voltage_i >> 8 & 0xff;
             can_mesg[6] = min_cell_voltage_i & 0xff;
             can_mesg[7] = min_cell_voltage_i >> 8 & 0xff;
+
             ESP_LOGI("main", "send can id: 0x70 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
-            return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # Actual Max Cell Temp ID, Min Cell Temp ID, Max Cell V ID, Min Cell ID
           can_id: 0x371
           data: !lambda |-
-            uint8_t can_mesg[7];
+            std::vector<uint8_t> can_mesg = {0, 0, 0, 0, 0, 0, 0, 0};
+
             can_mesg[0] = 0x01;
             can_mesg[1] = 0x00;
             can_mesg[2] = 0x02;
@@ -314,22 +358,26 @@ interval:
             can_mesg[5] = uint16_t(id(max_voltage_cell).state) >> 8 & 0xff;
             can_mesg[6] = uint16_t(id(min_voltage_cell).state) & 0xff;
             can_mesg[7] = uint16_t(id(min_voltage_cell).state) >> 8 & 0xff;
+
             ESP_LOGI("main", "send can id: 0x371 hex: %x %x %x %x %x %x %x %x", can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]);
-            return {can_mesg[0], can_mesg[1], can_mesg[2], can_mesg[3], can_mesg[4], can_mesg[5], can_mesg[6], can_mesg[7]};
+
+            return can_mesg;
+
       - delay: 10ms
 
       - canbus.send: # GOODWE
           can_id: 0x35E
           data: [0x47, 0x4F, 0x4F, 0x44, 0x57, 0x45, 0x20, 0x20]
+
       - delay: 10ms
 
       - lambda: |- # Detect no CAN reply
-           if (id(can_305_rx) > 30) {
-             ESP_LOGI("main", "No rx can 0x305 reply. Rebooting...");
-             id(restart_button).press();
-           } else {
-             id(can_305_rx) ++;
-           }
+          if (id(can_305_rx) > 30) {
+            ESP_LOGI("main", "No rx can 0x305 reply. Rebooting...");
+            id(restart_button).press();
+          } else {
+            id(can_305_rx) ++;
+          }
 
 binary_sensor:
   - platform: jk_bms
@@ -400,22 +448,22 @@ sensor:
       name: "${name} cell voltage 15"
     cell_voltage_16:
       name: "${name} cell voltage 16"
-#    cell_voltage_17:
-#      name: "${name} cell voltage 17"
-#    cell_voltage_18:
-#      name: "${name} cell voltage 18"
-#    cell_voltage_19:
-#      name: "${name} cell voltage 19"
-#    cell_voltage_20:
-#      name: "${name} cell voltage 20"
-#    cell_voltage_21:
-#      name: "${name} cell voltage 21"
-#    cell_voltage_22:
-#      name: "${name} cell voltage 22"
-#    cell_voltage_23:
-#      name: "${name} cell voltage 23"
-#    cell_voltage_24:
-#      name: "${name} cell voltage 24"
+    #    cell_voltage_17:
+    #      name: "${name} cell voltage 17"
+    #    cell_voltage_18:
+    #      name: "${name} cell voltage 18"
+    #    cell_voltage_19:
+    #      name: "${name} cell voltage 19"
+    #    cell_voltage_20:
+    #      name: "${name} cell voltage 20"
+    #    cell_voltage_21:
+    #      name: "${name} cell voltage 21"
+    #    cell_voltage_22:
+    #      name: "${name} cell voltage 22"
+    #    cell_voltage_23:
+    #      name: "${name} cell voltage 23"
+    #    cell_voltage_24:
+    #      name: "${name} cell voltage 24"
     power_tube_temperature:
       id: power_tube_temperature
       name: "${name} power tube temperature"
@@ -525,13 +573,13 @@ sensor:
       name: "${name} manufacturing date"
     total_runtime:
       name: "${name} total runtime"
-#    start_current_calibration:
-#      name: "${name} start current calibration"
+    #    start_current_calibration:
+    #      name: "${name} start current calibration"
     actual_battery_capacity:
       name: "${name} actual battery capacity"
-#    protocol_version:
-#      name: "${name} protocol version"
-# Uptime sensor
+  #    protocol_version:
+  #      name: "${name} protocol version"
+  # Uptime sensor
   - platform: uptime
     name: ${name} Uptime Sensor
     id: uptime_sensor
@@ -573,7 +621,7 @@ text_sensor:
       name: "${name} manufacturer"
     total_runtime_formatted:
       name: "${name} total runtime formatted"
-# Template text sensors
+  # Template text sensors
   - platform: template
     name: ${name} Uptime Human Readable
     id: uptime_human


### PR DESCRIPTION
Noticed some out-of-bound array indexing. You're lucky this wasn't segfaulting. I've replaced with vectors which is the native type that ESPHome uses behind the scenes. Also refactored the calculation of the voltages for easier reading.

I'm using this fork on my ESP32 which is hooked up to a JK-B2A20S20P and a Growatt SPF5000ES and it's working lovely. :-)